### PR TITLE
fix attributes of not a container element 

### DIFF
--- a/lib/htmlparser.js
+++ b/lib/htmlparser.js
@@ -46,7 +46,6 @@ function inherits (ctor, superCtor) {
 
 var Mode = {
     Text: 'text',
-    Script: 'script',
     Tag: 'tag',
     Attr: 'attr',
     CData: 'cdata',
@@ -96,7 +95,6 @@ if (typeof(module) !== 'undefined' && typeof(module.exports) !== 'undefined') {
     Parser.prototype.reset = function Parser$reset () {
         this._state = {
             mode: Mode.Text,
-            lastMode: Mode.Text,
             pos: 0,
             data: null,
             pendingText: null,
@@ -160,8 +158,6 @@ if (typeof(module) !== 'undefined' && typeof(module.exports) !== 'undefined') {
         switch (this._state.mode) {
             case Mode.Text:
                 return this._parseText(this._state);
-            case Mode.Script:
-                return this._parseScript(this._state);
             case Mode.Tag:
                 return this._parseTag(this._state);
             case Mode.Attr:
@@ -200,7 +196,6 @@ if (typeof(module) !== 'undefined' && typeof(module.exports) !== 'undefined') {
     Parser._re_parseText_scriptClose = /<\s*\/\s*script/ig;
     Parser.prototype._parseText = function Parser$_parseText () {
         var state = this._state;
-        var nextMode = Mode.Tag;
         var foundPos;
         if (state.isScript) {
             Parser._re_parseText_scriptClose.lastIndex = state.pos;
@@ -211,21 +206,7 @@ if (typeof(module) !== 'undefined' && typeof(module.exports) !== 'undefined') {
                 -1
                 ;
         } else {
-            foundTagOpenPos = state.data.indexOf('<', state.pos);
-            foundScriptPos = state.data.indexOf('{', state.pos);
-            if(foundScriptPos < 0){
-              nextMode = Mode.Tag;
-              foundPos = foundTagOpenPos;
-            }else{
-              if(foundTagOpenPos < 0 || foundScriptPos < foundTagOpenPos){
-                nextMode = Mode.Script;
-                state.lastMode = Mode.Text;
-                foundPos = foundScriptPos;
-              }else{
-                nextMode = Mode.Tag;
-                foundPos = foundTagOpenPos;
-              }
-            }
+            foundPos = state.data.indexOf('<', state.pos);
         }
         var text = (foundPos === -1) ? state.data.substring(state.pos, state.data.length) : state.data.substring(state.pos, foundPos);
         if (foundPos < 0 && state.done) {
@@ -253,37 +234,10 @@ if (typeof(module) !== 'undefined' && typeof(module.exports) !== 'undefined') {
                 this._write({ type: Mode.Text, data: text });
             }
             state.pos = foundPos + 1;
-            state.mode = nextMode;
+            state.mode = Mode.Tag;
         }
     };
 
-    Parser.prototype._parseScript = function Parser$_parseScript () {
-        var state = this._state;
-        var foundPos;
-        foundPos = state.data.indexOf('}', state.pos);
-        var text = (foundPos === -1) ? state.data.substring(state.pos, state.data.length) : state.data.substring(state.pos, foundPos);
-        if (foundPos < 0 && state.done) {
-            foundPos = state.data.length;
-        }
-        if (foundPos < 0) {
-            state.needData = true;
-            return;
-        } else {
-            if (state.pendingText) {
-                state.pendingText.push(state.data.substring(state.pos, foundPos));
-                text = state.pendingText.join('');
-                state.pendingText = null;
-            } else {
-                text = state.data.substring(state.pos, foundPos);
-            }
-            if (text !== '') {
-                this._write({ type: Mode.Script, data: text });
-            }
-            state.pos = foundPos + 1;
-            state.mode = state.lastMode;
-        }
-    };
-  
     Parser.re_parseTag = /\s*(\/?)\s*([^\s>\/]+)(\s*)\??(>?)/g;
     Parser.prototype._parseTag = function Parser$_parseTag () {
         var state = this._state;
@@ -443,16 +397,7 @@ if (typeof(module) !== 'undefined' && typeof(module.exports) !== 'undefined') {
         }
         state.lastTag.raw += name_data.match + value_data.match;
 
-        var data = {dataType:Mode.Text};
-        var foundCloseScriptPos = -1;
-        if (value_data.value) foundCloseScriptPos = value_data.value.indexOf('}');
-        if (foundCloseScriptPos > 0 && value_data.value.substr(0, 1) === '{' ) {
-          data.dataType = Mode.Script;
-          data.value = value_data.value.substr(1, foundCloseScriptPos-1);
-        }else{
-          data.value = value_data.value;
-        }
-        this._writePending({ type: Mode.Attr, name: name_data.name, data: data });
+        this._writePending({ type: Mode.Attr, name: name_data.name, data: value_data.value });
     };
 
     Parser.re_parseCData_findEnding = /\]{1,2}$/;
@@ -679,8 +624,8 @@ function HtmlBuilder (callback, options) {
         }
     };
 
-    HtmlBuilder.prototype._copyElement = function HtmlBuilder$_copyElement (element,parentNode) {
-        var newElement = { type: element.type, parentNode: parentNode};
+    HtmlBuilder.prototype._copyElement = function HtmlBuilder$_copyElement (element) {
+        var newElement = { type: element.type };
 
         if (this._options.verbose && element['raw'] !== undefined) {
             newElement.raw = element.raw;
@@ -754,7 +699,6 @@ function HtmlBuilder (callback, options) {
                     this._lastTag = node;
                 }
             } else if (element.type === Mode.Attr && this._lastTag) {
-              console.log(this._lastTag.attributes);
                 if (!this._lastTag.attributes) {
                     this._lastTag.attributes = {};
                 }
@@ -794,7 +738,7 @@ function HtmlBuilder (callback, options) {
                         parent.attributes[this._options.caseSensitiveAttr ? element.name : element.name.toLowerCase()] =
                             element.data;
                     } else {
-                        node = this._copyElement(element,parent);
+                        node = this._copyElement(element);
                         if (!parent.children) {
                             parent.children = [];
                         }
@@ -820,7 +764,7 @@ function HtmlBuilder (callback, options) {
                     if (!parent.children) {
                         parent.children = [];
                     }
-                    parent.children.push(this._copyElement(element,parent));
+                    parent.children.push(this._copyElement(element));
                 }
             }
         }
@@ -898,7 +842,7 @@ inherits(RssBuilder, HtmlBuilder);
                     feed.title = DomUtils.getElementsByTagName("title", feedRoot.children, false)[0].children[0].data;
                 } catch (ex) { }
                 try {
-                    feed.link = DomUtils.getElementsByTagName("link", feedRoot.children, false)[0].attributes.href.value;
+                    feed.link = DomUtils.getElementsByTagName("link", feedRoot.children, false)[0].attributes.href;
                 } catch (ex) { }
                 try {
                     feed.description = DomUtils.getElementsByTagName("subtitle", feedRoot.children, false)[0].children[0].data;
@@ -919,7 +863,7 @@ inherits(RssBuilder, HtmlBuilder);
                         entry.title = DomUtils.getElementsByTagName("title", item.children, false)[0].children[0].data;
                     } catch (ex) { }
                     try {
-                        entry.link = DomUtils.getElementsByTagName("link", item.children, false)[0].attributes.href.value;
+                        entry.link = DomUtils.getElementsByTagName("link", item.children, false)[0].attributes.href;
                     } catch (ex) { }
                     try {
                         entry.description = DomUtils.getElementsByTagName("summary", item.children, false)[0].children[0].data;
@@ -965,7 +909,7 @@ inherits(RssBuilder, HtmlBuilder);
                         return false;
                     }
                 } else {
-                    if (!element.attributes || !element.attributes[key] || !options[key](element.attributes[key].value)) {
+                    if (!element.attributes || !options[key](element.attributes[key])) {
                         return false;
                     }
                 }

--- a/lib/htmlparser.js
+++ b/lib/htmlparser.js
@@ -624,8 +624,8 @@ function HtmlBuilder (callback, options) {
         }
     };
 
-    HtmlBuilder.prototype._copyElement = function HtmlBuilder$_copyElement (element) {
-        var newElement = { type: element.type };
+    HtmlBuilder.prototype._copyElement = function HtmlBuilder$_copyElement (element,parentNode) {
+        var newElement = { type: element.type, parentNode: parentNode};
 
         if (this._options.verbose && element['raw'] !== undefined) {
             newElement.raw = element.raw;
@@ -738,7 +738,7 @@ function HtmlBuilder (callback, options) {
                         parent.attributes[this._options.caseSensitiveAttr ? element.name : element.name.toLowerCase()] =
                             element.data;
                     } else {
-                        node = this._copyElement(element);
+                        node = this._copyElement(element,parent);
                         if (!parent.children) {
                             parent.children = [];
                         }
@@ -764,7 +764,7 @@ function HtmlBuilder (callback, options) {
                     if (!parent.children) {
                         parent.children = [];
                     }
-                    parent.children.push(this._copyElement(element));
+                    parent.children.push(this._copyElement(element,parent));
                 }
             }
         }

--- a/lib/htmlparser.js
+++ b/lib/htmlparser.js
@@ -753,13 +753,20 @@ function HtmlBuilder (callback, options) {
                 }
             }
             else { //This is not a container element
-                parent = this._tagStack.last();
+                //parent = this._tagStack.last();
                 if (element.type === Mode.Attr) {
+                  if (!this._lastTag.attributes) {
+                      this._lastTag.attributes = {};
+                  }
+                  this._lastTag.attributes[this._options.caseSensitiveAttr ? element.name : element.name.toLowerCase()] =
+                      element.data;
+                  /*
                     if (!parent.attributes) {
                         parent.attributes = {};
                     }
                     parent.attributes[this._options.caseSensitiveAttr ? element.name : element.name.toLowerCase()] =
                         element.data;
+                  */
                 } else {
                     if (!parent.children) {
                         parent.children = [];

--- a/lib/htmlparser.js
+++ b/lib/htmlparser.js
@@ -46,6 +46,7 @@ function inherits (ctor, superCtor) {
 
 var Mode = {
     Text: 'text',
+    Script: 'script',
     Tag: 'tag',
     Attr: 'attr',
     CData: 'cdata',
@@ -95,6 +96,7 @@ if (typeof(module) !== 'undefined' && typeof(module.exports) !== 'undefined') {
     Parser.prototype.reset = function Parser$reset () {
         this._state = {
             mode: Mode.Text,
+            lastMode: Mode.Text,
             pos: 0,
             data: null,
             pendingText: null,
@@ -158,6 +160,8 @@ if (typeof(module) !== 'undefined' && typeof(module.exports) !== 'undefined') {
         switch (this._state.mode) {
             case Mode.Text:
                 return this._parseText(this._state);
+            case Mode.Script:
+                return this._parseScript(this._state);
             case Mode.Tag:
                 return this._parseTag(this._state);
             case Mode.Attr:
@@ -196,6 +200,7 @@ if (typeof(module) !== 'undefined' && typeof(module.exports) !== 'undefined') {
     Parser._re_parseText_scriptClose = /<\s*\/\s*script/ig;
     Parser.prototype._parseText = function Parser$_parseText () {
         var state = this._state;
+        var nextMode = Mode.Tag;
         var foundPos;
         if (state.isScript) {
             Parser._re_parseText_scriptClose.lastIndex = state.pos;
@@ -206,7 +211,21 @@ if (typeof(module) !== 'undefined' && typeof(module.exports) !== 'undefined') {
                 -1
                 ;
         } else {
-            foundPos = state.data.indexOf('<', state.pos);
+            foundTagOpenPos = state.data.indexOf('<', state.pos);
+            foundScriptPos = state.data.indexOf('{', state.pos);
+            if(foundScriptPos < 0){
+              nextMode = Mode.Tag;
+              foundPos = foundTagOpenPos;
+            }else{
+              if(foundTagOpenPos < 0 || foundScriptPos < foundTagOpenPos){
+                nextMode = Mode.Script;
+                state.lastMode = Mode.Text;
+                foundPos = foundScriptPos;
+              }else{
+                nextMode = Mode.Tag;
+                foundPos = foundTagOpenPos;
+              }
+            }
         }
         var text = (foundPos === -1) ? state.data.substring(state.pos, state.data.length) : state.data.substring(state.pos, foundPos);
         if (foundPos < 0 && state.done) {
@@ -234,10 +253,37 @@ if (typeof(module) !== 'undefined' && typeof(module.exports) !== 'undefined') {
                 this._write({ type: Mode.Text, data: text });
             }
             state.pos = foundPos + 1;
-            state.mode = Mode.Tag;
+            state.mode = nextMode;
         }
     };
 
+    Parser.prototype._parseScript = function Parser$_parseScript () {
+        var state = this._state;
+        var foundPos;
+        foundPos = state.data.indexOf('}', state.pos);
+        var text = (foundPos === -1) ? state.data.substring(state.pos, state.data.length) : state.data.substring(state.pos, foundPos);
+        if (foundPos < 0 && state.done) {
+            foundPos = state.data.length;
+        }
+        if (foundPos < 0) {
+            state.needData = true;
+            return;
+        } else {
+            if (state.pendingText) {
+                state.pendingText.push(state.data.substring(state.pos, foundPos));
+                text = state.pendingText.join('');
+                state.pendingText = null;
+            } else {
+                text = state.data.substring(state.pos, foundPos);
+            }
+            if (text !== '') {
+                this._write({ type: Mode.Script, data: text });
+            }
+            state.pos = foundPos + 1;
+            state.mode = state.lastMode;
+        }
+    };
+  
     Parser.re_parseTag = /\s*(\/?)\s*([^\s>\/]+)(\s*)\??(>?)/g;
     Parser.prototype._parseTag = function Parser$_parseTag () {
         var state = this._state;
@@ -397,7 +443,16 @@ if (typeof(module) !== 'undefined' && typeof(module.exports) !== 'undefined') {
         }
         state.lastTag.raw += name_data.match + value_data.match;
 
-        this._writePending({ type: Mode.Attr, name: name_data.name, data: value_data.value });
+        var data = {dataType:Mode.Text};
+        var foundCloseScriptPos = -1;
+        if (value_data.value) foundCloseScriptPos = value_data.value.indexOf('}');
+        if (foundCloseScriptPos > 0 && value_data.value.substr(0, 1) === '{' ) {
+          data.dataType = Mode.Script;
+          data.value = value_data.value.substr(1, foundCloseScriptPos-1);
+        }else{
+          data.value = value_data.value;
+        }
+        this._writePending({ type: Mode.Attr, name: name_data.name, data: data });
     };
 
     Parser.re_parseCData_findEnding = /\]{1,2}$/;
@@ -699,6 +754,7 @@ function HtmlBuilder (callback, options) {
                     this._lastTag = node;
                 }
             } else if (element.type === Mode.Attr && this._lastTag) {
+              console.log(this._lastTag.attributes);
                 if (!this._lastTag.attributes) {
                     this._lastTag.attributes = {};
                 }
@@ -842,7 +898,7 @@ inherits(RssBuilder, HtmlBuilder);
                     feed.title = DomUtils.getElementsByTagName("title", feedRoot.children, false)[0].children[0].data;
                 } catch (ex) { }
                 try {
-                    feed.link = DomUtils.getElementsByTagName("link", feedRoot.children, false)[0].attributes.href;
+                    feed.link = DomUtils.getElementsByTagName("link", feedRoot.children, false)[0].attributes.href.value;
                 } catch (ex) { }
                 try {
                     feed.description = DomUtils.getElementsByTagName("subtitle", feedRoot.children, false)[0].children[0].data;
@@ -863,7 +919,7 @@ inherits(RssBuilder, HtmlBuilder);
                         entry.title = DomUtils.getElementsByTagName("title", item.children, false)[0].children[0].data;
                     } catch (ex) { }
                     try {
-                        entry.link = DomUtils.getElementsByTagName("link", item.children, false)[0].attributes.href;
+                        entry.link = DomUtils.getElementsByTagName("link", item.children, false)[0].attributes.href.value;
                     } catch (ex) { }
                     try {
                         entry.description = DomUtils.getElementsByTagName("summary", item.children, false)[0].children[0].data;
@@ -909,7 +965,7 @@ inherits(RssBuilder, HtmlBuilder);
                         return false;
                     }
                 } else {
-                    if (!element.attributes || !options[key](element.attributes[key])) {
+                    if (!element.attributes || !element.attributes[key] || !options[key](element.attributes[key].value)) {
                         return false;
                     }
                 }


### PR DESCRIPTION
ex. 

```
  <div id="Container">
    <input type="text" value="Hello World!" />
  </div>
```

Before 

```
    {
        "type": "tag",
        "name": "div",
        "attributes": {
            "id": "Container",
            "type": "text",
            "value": "Hello World!"
        },
        "children": [
            {
                "type": "tag",
                "name": "input"
            }
        ]
    },
```

After

```
    {
        "type": "tag",
        "name": "div",
        "attributes": {
            "id": "Container"
        },
        "children": [
            {
                "type": "tag",
                "name": "input",
                "attributes": {
                    "type": "text",
                    "value": "Hello World!"
                }
            }
        ]
    },
```
